### PR TITLE
Réduire l'espace titre timeline

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -7,7 +7,7 @@
   font-size: 1.2rem;
   font-weight: 700;
   color: #fafafa;
-  margin-bottom: 2rem;
+  margin-bottom: 0.75rem;
   text-align: start;
 }
 
@@ -102,7 +102,7 @@
   .experience-content {
     grid-template-columns: 1fr;
     gap: 3rem;
-    margin-top: 2rem;
+    margin-top: 0.75rem;
   }
   
   .subsection-title {


### PR DESCRIPTION
Reduce spacing between the section title and the timeline content.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ce0e568-2a1e-4355-be63-16144a1287a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ce0e568-2a1e-4355-be63-16144a1287a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

