### PR TITLE
Centre le point de la timeline sur mobile

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -151,12 +151,16 @@
     margin-bottom: 1.5rem;
   }
   
+  .timeline::before {
+    left: 0.75rem; /* Centre la ligne avec les points */
+  }
+  
   .timeline-item {
     padding-left: 2.5rem;
   }
   
   .timeline-marker {
-    left: 0.25rem;
+    left: 0.25rem; /* Centré par rapport à la ligne */
   }
   
   .timeline-header {


### PR DESCRIPTION
Adjust the `left` position of the timeline vertical line on mobile to center it with the markers.

---
<a href="https://cursor.com/background-agent?bcId=bc-592170a7-a218-41d5-b491-6e2d995b11a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-592170a7-a218-41d5-b491-6e2d995b11a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

