### PR TITLE
Centre le point de la timeline sur mobile

### DIFF
--- a/src/components/Experience.css
+++ b/src/components/Experience.css
@@ -51,13 +51,14 @@
 
 .timeline-marker {
   position: absolute;
-  left: 0.5rem;
+  left: 1rem;
   top: 0.5rem;
   width: 1rem;
   height: 1rem;
   background: #fafafa;
   border-radius: 50%;
   border: 3px solid #0a0a0a;
+  transform: translateX(-50%);
 }
 
 .timeline-header {
@@ -156,7 +157,7 @@
   }
   
   .timeline-marker {
-    left: 0.25rem;
+    left: 1rem;
   }
   
   .timeline-header {


### PR DESCRIPTION
Center the timeline marker for better visual alignment on mobile and other screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ac7e39a-843f-4773-99e8-c95a4b7755ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ac7e39a-843f-4773-99e8-c95a4b7755ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

